### PR TITLE
Add a rule to enforce TypeORM's Relation<...>-wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,8 @@ class Entity {
 Examples of **correct code** for this rule:
 
 ```ts
+import { Relation } from 'typeorm';
+
 class Entity {
     // Join is correctly nullable...
     @OneToOne(() => Other)
@@ -190,6 +192,11 @@ class Entity {
     // *ToMany rules are an array
     @OneToMany(() => Other, (other) => other.entity)
     others: Other[];
+
+    // Even accepts if you wrap the relation type with the typeorm Relation<...>-wrapper
+    @OneToOne(() => Other, { nullable: true })
+    @JoinColumn()
+    other: Relation<Other> | null;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,9 +22,9 @@ import tseslint from 'typescript-eslint';
 import typeormTypescriptRecommended from 'eslint-plugin-typeorm-typescript/recommended';
 
 export default tseslint.config(
-  eslint.configs.recommended,
-  ...tseslint.configs.recommended,
-  typeormTypescriptRecommended,
+    eslint.configs.recommended,
+    ...tseslint.configs.recommended,
+    typeormTypescriptRecommended,
 );
 ```
 
@@ -35,18 +35,17 @@ import eslint from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import typeormTypescriptPlugin from 'eslint-plugin-typeorm-typescript';
 
-export default tseslint.config(
-  eslint.configs.recommended,
-  ...tseslint.configs.recommended,
-  {
-    plugins: {'typeorm-typescript': typeormTypescriptPlugin},
+export default tseslint.config(eslint.configs.recommended, ...tseslint.configs.recommended, {
+    plugins: { 'typeorm-typescript': typeormTypescriptPlugin },
     rules: {
-      "typeorm-typescript/enforce-column-types": "error",
-      "typeorm-typescript/enforce-relation-types": "warn",
-      "typeorm-typescript/enforce-consistent-nullability": ["error", { "specifyNullable": "always" }]
-    }
-  }
-);
+        'typeorm-typescript/enforce-column-types': 'error',
+        'typeorm-typescript/enforce-relation-types': 'warn',
+        'typeorm-typescript/enforce-consistent-nullability': [
+            'error',
+            { specifyNullable: 'always' },
+        ],
+    },
+});
 ```
 
 For more information, see an example of the [recommended configuration](./examples/recommended/).
@@ -57,12 +56,12 @@ If you are still on legacy ESLint, update `.eslintrc.json` with the plugin to th
 
 ```json
 {
-  "plugins": ["typeorm-typescript"],
-  "rules": {
-    "typeorm-typescript/enforce-column-types": "error",
-    "typeorm-typescript/enforce-relation-types": "error",
-    "typeorm-typescript/enforce-consistent-nullability": "error"
-  }
+    "plugins": ["typeorm-typescript"],
+    "rules": {
+        "typeorm-typescript/enforce-column-types": "error",
+        "typeorm-typescript/enforce-relation-types": "error",
+        "typeorm-typescript/enforce-consistent-nullability": "error"
+    }
 }
 ```
 
@@ -87,9 +86,9 @@ It also handle primary columns (`number` by default), create and update columns 
 
 ```json
 {
-  "rules": {
-    "typeorm-typescript/enforce-column-types": "error"
-  }
+    "rules": {
+        "typeorm-typescript/enforce-column-types": "error"
+    }
 }
 ```
 
@@ -100,11 +99,11 @@ Examples of **incorrect code** for this rule:
 ```ts
 class Entity {
     // Should be string
-    @Column({ type: "varchar" })
+    @Column({ type: 'varchar' })
     name: number;
 
     // Should be string | null
-    @Column({ type: "varchar", nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     name: string;
 
     // Should be Date | null
@@ -118,11 +117,11 @@ Examples of **correct code** for this rule:
 ```ts
 class Entity {
     // TypeORM data type and TypeScript type are consistent
-    @Column({ type: "varchar" })
+    @Column({ type: 'varchar' })
     name: string;
 
     // Nullability is correct
-    @Column({ type: "varchar", nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     name: string | null;
 }
 ```
@@ -137,9 +136,9 @@ which is an easy mistake to make.
 
 ```json
 {
-  "rules": {
-    "typeorm-typescript/enforce-relation-types": "error"
-  }
+    "rules": {
+        "typeorm-typescript/enforce-relation-types": "error"
+    }
 }
 ```
 
@@ -207,9 +206,15 @@ that either only the non-default value is set (no parameters or `non-default`) o
     "rules": {
         // If you want to report an error for unnecessary nullables
         "typeorm-typescript/enforce-consistent-nullability": "error", // or
-        "typeorm-typescript/enforce-consistent-nullability": ["error", { "specifyNullable": "non-default" }],
+        "typeorm-typescript/enforce-consistent-nullability": [
+            "error",
+            { "specifyNullable": "non-default" },
+        ],
         // If you want to force setting nullable everywhere to avoid confusion
-        "typeorm-typescript/enforce-consistent-nullability": ["error", { "specifyNullable": "always" }],
+        "typeorm-typescript/enforce-consistent-nullability": [
+            "error",
+            { "specifyNullable": "always" },
+        ],
     },
 }
 ```
@@ -223,7 +228,7 @@ With `{ "specifyNullable": "non-default" }`:
 ```ts
 class Entity {
     // Columns are non-nullable by default, remove it
-    @Column({ type: "varchar", nullable: false })
+    @Column({ type: 'varchar', nullable: false })
     name: number;
 
     // Relations are nullable by default, remove it
@@ -238,7 +243,7 @@ With `{ "specifyNullable": "always" }`:
 ```ts
 class Entity {
     // Mark this to nullable false to make it clear
-    @Column({ type: "varchar" })
+    @Column({ type: 'varchar' })
     name: number;
 
     // Mark this to nullable true to make it clear
@@ -255,10 +260,10 @@ With `{ "specifyNullable": "non-default" }`:
 ```ts
 class Entity {
     // Nullability only defined when it is different than default
-    @Column({ type: "varchar", nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     middleName: number | null;
 
-    @Column({ type: "varchar" })
+    @Column({ type: 'varchar' })
     name: number;
 
     @OneToOne(() => Other)
@@ -272,14 +277,64 @@ With `{ "specifyNullable": "always" }`:
 ```ts
 class Entity {
     // Nullable is set everywhere, no default behaviour is implied
-    @Column({ type: "varchar", nullable: true })
+    @Column({ type: 'varchar', nullable: true })
     middleName: number | null;
 
-    @Column({ type: "varchar", nullable: false })
+    @Column({ type: 'varchar', nullable: false })
     name: number;
 
     @OneToOne(() => Other, { nullable: true })
     @JoinColumn()
     other: Other | null;
+}
+```
+
+### typeorm-typescript/enforce-relation-wrapper
+
+TypeORM offers a Relation wrapper which is required when migrating to ESM, to avoid dependency issues. See also [Relations in ESM projects](https://typeorm.io/#relations-in-esm-projects). However, esp. during migration to ESM it may happen that all relations must be updated by hand, which might be very cumbersome. This rule allows to enforce the Relation<...>-wrapper and also may fix your code to do the migration for you.
+
+#### Configuration
+
+```json
+{
+    "rules": {
+        "typeorm-typescript/enforce-relation-wrapper": "error"
+    }
+}
+```
+
+#### Examples
+
+Examples of **incorrect code** for this rule:
+
+```ts
+class Entity {
+    // Should be Relation<Other> | null
+    @OneToOne(() => Other)
+    @JoinColumn()
+    other: Other | null;
+
+    // Should be Relation<Other[]>
+    @OneToMany(() => Other, (other) => other.entity)
+    other: Other[];
+
+    // Should be Relation<Other> | null
+    @ManyToOne(() => Other)
+    other: Other;
+}
+```
+
+Examples of **correct code** for this rule:
+
+```ts
+class Entity {
+    // Join is correctly nullable relation ....
+    @OneToOne(() => Other)
+    @JoinColumn()
+    other: Relation<Other> | null;
+
+    // *ToMany rules are an array relation
+    @OneToMany(() => Other, (other) => other.entity)
+    others: Relation<Other[]>;
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,12 +2,14 @@ import { FlatConfig } from '@typescript-eslint/utils/ts-eslint';
 import enforceColumnTypes from './rules/enforce-column-types.js';
 import enforceConsistentNullability from './rules/enforce-consistent-nullability.js';
 import enforceRelationTypes from './rules/enforce-relation-types.js';
+import enforceRelationWrapper from './rules/enforce-relation-wrapper.js';
 import recommended from './recommended.js';
 
 export const rules = {
     'enforce-column-types': enforceColumnTypes,
     'enforce-consistent-nullability': enforceConsistentNullability,
     'enforce-relation-types': enforceRelationTypes,
+    'enforce-relation-wrapper': enforceRelationWrapper,
 };
 
 export const plugin: FlatConfig.Plugin = {

--- a/src/rules/enforce-relation-types.test.ts
+++ b/src/rules/enforce-relation-types.test.ts
@@ -141,6 +141,51 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
                 others: Promise<Other[]>;
             }`,
         },
+        {
+            name: 'should allow lazy relations wrapped with Relation<...> wrapper array',
+            code: `import { Relation } from 'typeorm';
+            class Entity {
+                @ManyToMany(() => Other)
+                @JoinTable()
+                others: Promise<Relation<Other>[]>;
+            }`,
+        },
+        {
+            name: 'should allow lazy relations array with Relation<...> wrapper',
+            code: `import { Relation } from 'typeorm';
+            class Entity {
+                @ManyToMany(() => Other)
+                @JoinTable()
+                others: Promise<Relation<Other[]>>;
+            }`,
+        },
+        {
+            name: 'should allow scalar relations wrapped with Relation<...> wrapper',
+            code: `import { Relation } from 'typeorm';
+            class Entity {
+                @OneToOne(() => Other)
+                @JoinTable()
+                others: Relation<Other> | null;
+            }`,
+        },
+        {
+            name: 'should allow nullable relations wrapped with Relation<...> wrapper covering null',
+            code: `import { Relation } from 'typeorm';
+            class Entity {
+                @OneToOne(() => Other, { nullable: true })
+                @JoinTable()
+                others: Relation<Other | null>;
+            }`,
+        },
+        {
+            name: 'should allow nullable relations wrapped with Relation<...> wrapper not covering null',
+            code: `import { Relation } from 'typeorm';
+            class Entity {
+                @OneToOne(() => Other, { nullable: true })
+                @JoinTable()
+                others: Relation<Other> | null;
+            }`,
+        },
     ],
     invalid: [
         {

--- a/src/rules/enforce-relation-wrapper.test.ts
+++ b/src/rules/enforce-relation-wrapper.test.ts
@@ -1,0 +1,99 @@
+import path from 'path';
+import * as vitest from 'vitest';
+import tsParser from '@typescript-eslint/parser';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import rule from './enforce-relation-wrapper.js';
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parser: tsParser,
+        parserOptions: {
+            project: './tsconfig.json',
+            tsconfigRootDir: path.join(__dirname, '../../tests'),
+        },
+    },
+});
+
+ruleTester.run('enforce-relation-wrapper', rule, {
+    valid: [
+        {
+            name: 'should "see" aliased imports',
+            code: `import { OneToMany as OTM, Relation as Foreign } from 'typeorm'
+                class Foo {
+                    @OTM(() => Bar)
+                    prop: Foreign<Bar> | undefined
+                }`,
+        },
+        {
+            name: 'should respect current code as long as all wrappings are okay',
+            code: `import { OneToMany, Relation } from 'typeorm'
+                class Foo {
+                    @OneToMany(() => Bar)
+                    prop: Relation<Bar> | Relation<Baz | undefined>
+                }`,
+        },
+    ],
+    invalid: [
+        {
+            name: 'should fail due to missing Relation<...>-wrapper',
+            code: `import { OneToMany } from 'typeorm'
+                class Foo {
+                    @OneToMany(() => Bar)
+                    prop: Bar | undefined
+                }`,
+            errors: [{ messageId: 'expectedRelation' }, { messageId: 'preferRelation' }],
+            output: `import { OneToMany, Relation } from 'typeorm'
+                class Foo {
+                    @OneToMany(() => Bar)
+                    prop: Relation<Bar> | undefined
+                }`,
+        },
+        {
+            name: 'should fail due to missing Relation<...>-wrapper with aliased decorator',
+            code: `import { OneToMany as OTM } from 'typeorm'
+                class Foo {
+                    @OTM(() => Bar)
+                    prop: Bar | undefined
+                }`,
+            errors: [{ messageId: 'expectedRelation' }, { messageId: 'preferRelation' }],
+            output: `import { OneToMany as OTM, Relation } from 'typeorm'
+                class Foo {
+                    @OTM(() => Bar)
+                    prop: Relation<Bar> | undefined
+                }`,
+        },
+        {
+            name: 'should fail due to missing Relation<...>-wrapper but respects wrapper alias',
+            code: `import { OneToMany, Relation as Reference } from 'typeorm'
+                class Foo {
+                    @OneToMany(() => Bar)
+                    prop: Bar | undefined
+                }`,
+            errors: [{ messageId: 'preferRelation' }],
+            output: `import { OneToMany, Relation as Reference } from 'typeorm'
+                class Foo {
+                    @OneToMany(() => Bar)
+                    prop: Reference<Bar> | undefined
+                }`,
+        },
+        {
+            name: 'should fail due to partially missing Relation<...>-wrapper',
+            code: `import { OneToMany } from 'typeorm'
+                class Foo {
+                    @OneToMany(() => Bar)
+                    prop: Relation<Foo> | Bar | undefined
+                }`,
+            errors: [{ messageId: 'expectedRelation' }, { messageId: 'preferRelation' }],
+            output: `import { OneToMany, Relation } from 'typeorm'
+                class Foo {
+                    @OneToMany(() => Bar)
+                    prop: Relation<Foo | Bar> | undefined
+                }`,
+        },
+    ],
+});

--- a/src/rules/enforce-relation-wrapper.ts
+++ b/src/rules/enforce-relation-wrapper.ts
@@ -1,0 +1,137 @@
+import { ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+
+const createRule = ESLintUtils.RuleCreator((name) => name);
+
+const relationDecorators = ['OneToOne', 'OneToMany', 'ManyToOne', 'ManyToMany'] as const;
+
+const rule = createRule({
+    name: 'enforce-relation-wrapper',
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description: 'Avoid statically typed relations and prefer the Relation<...>-wrapper.',
+        },
+        messages: {
+            preferRelation: 'Better use Relation<...>-wrapper for relation types.',
+            expectedRelation:
+                'When importing a relation decorator, the Relation<...>-wrapper is also expected to be imported.',
+        },
+        schema: [],
+        fixable: 'code',
+        hasSuggestions: true,
+    },
+    defaultOptions: [],
+    create(context) {
+        const alias = {
+            Relation: 'Relation',
+            OneToMany: 'OneToMany',
+            ManyToOne: 'ManyToOne',
+            OneToOne: 'OneToOne',
+            ManyToMany: 'ManyToMany',
+        };
+        let relationAliases: string[];
+
+        function getWrapping(
+            typeNode: TSESTree.TypeNode,
+            wrappedTypes: TSESTree.TypeNode[],
+            unwrappedTypes: TSESTree.TypeNode[],
+        ): boolean {
+            let fixRequired = false;
+            if (typeNode.type === TSESTree.AST_NODE_TYPES.TSUnionType)
+                for (const type of typeNode.types) {
+                    fixRequired = getWrapping(type, wrappedTypes, unwrappedTypes) || fixRequired;
+                }
+            else if (typeNode.type === TSESTree.AST_NODE_TYPES.TSTypeReference) {
+                const { typeName, typeArguments } = typeNode;
+                if (
+                    typeName.type === TSESTree.AST_NODE_TYPES.Identifier &&
+                    typeName.name === alias.Relation &&
+                    typeArguments?.params.length === 1
+                ) {
+                    // intentionally skip "fixRequired" here as types are already wrapped
+                    for (const typeArgument of typeArguments.params)
+                        getWrapping(typeArgument, wrappedTypes, unwrappedTypes);
+                } else {
+                    wrappedTypes.push(typeNode);
+                    fixRequired = true;
+                }
+            } else unwrappedTypes.push(typeNode);
+
+            return fixRequired;
+        }
+
+        return {
+            ImportDeclaration(node) {
+                if (node.source.value !== 'typeorm') return;
+                let requiresImportRelation = false,
+                    relationImported = false;
+                for (const specifier of node.specifiers) {
+                    if (specifier.type !== TSESTree.AST_NODE_TYPES.ImportSpecifier) continue;
+                    const { imported } = specifier;
+                    if (relationDecorators.includes(imported.name as never)) {
+                        alias[imported.name as keyof typeof alias] = specifier.local.name;
+                        requiresImportRelation = true;
+                    }
+                    if (imported.name === 'Relation') {
+                        alias.Relation = specifier.local.name;
+                        relationImported = true;
+                        continue;
+                    }
+                }
+                if (requiresImportRelation && !relationImported)
+                    context.report({
+                        messageId: 'expectedRelation',
+                        node,
+                        fix(fixer) {
+                            const lastSpec = node.specifiers[node.specifiers.length - 1];
+                            return fixer.replaceText(
+                                lastSpec,
+                                context.sourceCode.getText(lastSpec) + ', Relation',
+                            );
+                        },
+                    });
+            },
+            PropertyDefinition(node) {
+                if (!relationAliases)
+                    relationAliases = [...relationDecorators.map((_) => alias[_])];
+
+                for (const decorator of node.decorators) {
+                    if (decorator.expression.type !== TSESTree.AST_NODE_TYPES.CallExpression)
+                        continue;
+
+                    const { callee } = decorator.expression;
+                    if (callee.type !== TSESTree.AST_NODE_TYPES.Identifier) continue;
+
+                    if (relationAliases.includes(callee.name) && node.typeAnnotation) {
+                        const wrappedTypes: TSESTree.TypeNode[] = [];
+                        const unwrappedTypes: TSESTree.TypeNode[] = [];
+
+                        const { typeAnnotation } = node.typeAnnotation;
+
+                        if (!getWrapping(typeAnnotation, wrappedTypes, unwrappedTypes)) return;
+
+                        const relation = wrappedTypes
+                            .map((type) => context.sourceCode.getText(type))
+                            .join(' | ');
+
+                        const replacement = [
+                            `${alias.Relation}<${relation}>`,
+                            ...unwrappedTypes.map((type) => context.sourceCode.getText(type)),
+                        ].join(' | ');
+
+                        // if (type.includes('Relation<')) return;
+                        context.report({
+                            messageId: 'preferRelation',
+                            node: typeAnnotation,
+                            fix(fixer) {
+                                return fixer.replaceTextRange(typeAnnotation.range, replacement);
+                            },
+                        });
+                    }
+                }
+            },
+        };
+    },
+});
+
+export default rule;


### PR DESCRIPTION
When migrating to ESM this wrapper is required to avoid dependency conflicts. The new rule `enforce-relation-wrapper` avoids to forget this wrapper and makes migration to ESM on an existing codebase pretty easy (since are not updated by hand)

See: https://typeorm.io/#relations-in-esm-projects

Additionally I added support for this wrapper also to the existing rules, that they do not raise issues if references are wrapped as e.g. `Relation<Other>`

Happy to discuss this!