### PR TITLE
Add support for ESM Relation wrapper

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 ### Added
 
 - Add support for [ESM Relation wrapper](https://typeorm.io/#relations-in-esm-projects) ([#16](https://github.com/daniel7grant/eslint-plugin-typeorm-typescript/pull/16), [#17](https://github.com/daniel7grant/eslint-plugin-typeorm-typescript/issues/17), thanks to @lmeysel for initial implementation)
-
+- Add option to `enforce-relation-type` to make sure that relation wrapper is specified everywhere
 
 ## [0.4.0] - 2024-08-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## [Unreleased]
 
+### Added
+
+- Add support for [ESM Relation wrapper](https://typeorm.io/#relations-in-esm-projects) ([#16](https://github.com/daniel7grant/eslint-plugin-typeorm-typescript/pull/16), [#17](https://github.com/daniel7grant/eslint-plugin-typeorm-typescript/issues/17), thanks to @lmeysel for initial implementation)
+
+
 ## [0.4.0] - 2024-08-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -133,12 +133,18 @@ TypeORM relation types and TypeScript types should be consistent. Because the na
 that `ManyToOne` should be singular, and `OneToMany` an array. Additionally, `OneToOne` and `ManyToOne` are nullable,
 which is an easy mistake to make.
 
+This rule also supports the [ESM Relation wrapper](https://typeorm.io/#relations-in-esm-projects). If you are using ES Modules
+and want to avoid circular dependency issues, you can set `specifyRelation` to always to make sure that relations are always
+wrapped with `Relation<...>`.
+
 #### Configuration
 
 ```json
 {
   "rules": {
-    "typeorm-typescript/enforce-relation-types": "error"
+    "typeorm-typescript/enforce-relation-types": "error",
+    // If you want to force setting Relation<...> everywhere
+    "typeorm-typescript/enforce-relation-types": ["error", { "specifyRelation": "always" }],
   }
 }
 ```

--- a/examples/legacy/index.ts
+++ b/examples/legacy/index.ts
@@ -1,7 +1,22 @@
-import { Entity, Column } from 'typeorm';
+import { Entity, Column, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
-@Entity({ name: 'User' })
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: 'number' })
+    userId: number;
+}
+
+@Entity()
 export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
     @Column({ type: 'string' })
     name: number;
+
+    @OneToMany(() => Post, (post) => post.userId)
+    posts: Post;
 }

--- a/examples/recommended/index.ts
+++ b/examples/recommended/index.ts
@@ -1,7 +1,22 @@
-import { Entity, Column } from 'typeorm';
+import { Entity, Column, OneToMany, PrimaryGeneratedColumn } from 'typeorm';
 
-@Entity({ name: 'User' })
+@Entity()
+export class Post {
+    @PrimaryGeneratedColumn()
+    id: number;
+
+    @Column({ type: 'number' })
+    userId: number;
+}
+
+@Entity()
 export class User {
+    @PrimaryGeneratedColumn()
+    id: number;
+
     @Column({ type: 'string' })
     name: number;
+
+    @OneToMany(() => Post, (post) => post.userId)
+    posts: Post;
 }

--- a/src/rules/enforce-relation-types.test.ts
+++ b/src/rules/enforce-relation-types.test.ts
@@ -70,6 +70,22 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
             }`,
         },
         {
+            name: 'should allow valid wrapped one-to-one relations',
+            code: `class Entity {
+                @OneToOne(() => Other)
+                @JoinColumn()
+                other: Relation<Other | null>;
+            }`,
+        },
+        {
+            name: 'should allow valid wrapped non-nullable one-to-one relations',
+            code: `class Entity {
+                @OneToOne(() => Other, { nullable: false })
+                @JoinColumn()
+                other: Relation<Other>;
+            }`,
+        },
+        {
             name: 'should allow valid one-to-many relations',
             code: `class Entity {
                 @OneToMany(() => Other, (other) => other.entity)
@@ -81,6 +97,13 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
             code: `class Entity {
                 @OneToMany(() => Other, (other) => other.entity)
                 others: Promise<Other[]>;
+            }`,
+        },
+        {
+            name: 'should allow wrapped one-to-many relations',
+            code: `class Entity {
+                @OneToMany(() => Other, (other) => other.entity)
+                others: Relation<Other[]>;
             }`,
         },
         {
@@ -126,6 +149,20 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
             }`,
         },
         {
+            name: 'should allow valid wrapped many-to-one relations',
+            code: `class Entity {
+                @ManyToOne(() => Other)
+                other: Relation<Other | null>;
+            }`,
+        },
+        {
+            name: 'should allow valid wrapped non-nullable many-to-one relations',
+            code: `class Entity {
+                @ManyToOne(() => Other, { nullable: false })
+                other: Relation<Other>;
+            }`,
+        },
+        {
             name: 'should allow valid many-to-many relations',
             code: `class Entity {
                 @ManyToMany(() => Other)
@@ -139,6 +176,14 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
                 @ManyToMany(() => Other)
                 @JoinTable()
                 others: Promise<Other[]>;
+            }`,
+        },
+        {
+            name: 'should allow wrapped many-to-many relations',
+            code: `class Entity {
+                @ManyToMany(() => Other)
+                @JoinTable()
+                others: Relation<Other[]>;
             }`,
         },
     ],
@@ -234,7 +279,7 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
             ],
         },
         {
-            name: 'should fail on mismatched one-to-one promise relations',
+            name: 'should fail on mismatched one-to-one lazy relations',
             code: `class Entity {
                 @OneToOne(() => Other)
                 @JoinColumn()
@@ -250,6 +295,29 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
                 @OneToOne(() => Other)
                 @JoinColumn()
                 other: Promise<Other | null>;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on mismatched one-to-one wrapped relations',
+            code: `class Entity {
+                @OneToOne(() => Other)
+                @JoinColumn()
+                other: Relation<Another | null>;
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                @OneToOne(() => Other)
+                @JoinColumn()
+                other: Relation<Other | null>;
             }`,
                         },
                     ],
@@ -389,6 +457,27 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
             ],
         },
         {
+            name: 'should fail on mismatched wrapped one-to-many relations',
+            code: `class Entity {
+                    @OneToMany(() => Other, (other) => other.entity)
+                    others: Relation<Another[]>;
+                }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                    @OneToMany(() => Other, (other) => other.entity)
+                    others: Relation<Other[]>;
+                }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
             name: 'should fail on primitive one-to-many relations',
             code: `class Entity {
                 @OneToMany(() => Other, (other) => other.entity)
@@ -480,7 +569,7 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
             ],
         },
         {
-            name: 'should fail on mismatched many-to-one relations',
+            name: 'should fail on mismatched lazy many-to-one relations',
             code: `class Entity {
                 @ManyToOne(() => Other)
                 other: Promise<Another | null>;
@@ -494,6 +583,27 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
                             output: `class Entity {
                 @ManyToOne(() => Other)
                 other: Promise<Other | null>;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on mismatched wrapped many-to-one relations',
+            code: `class Entity {
+                @ManyToOne(() => Other)
+                other: Relation<Another | null>;
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                @ManyToOne(() => Other)
+                other: Relation<Other | null>;
             }`,
                         },
                     ],
@@ -605,6 +715,29 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
                 @ManyToMany(() => Other)
                 @JoinTable()
                 others: Promise<Other[]>;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on mismatched wrapped many-to-many relations',
+            code: `class Entity {
+                @ManyToMany(() => Other)
+                @JoinTable()
+                others: Relation<Another[]>;
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                @ManyToMany(() => Other)
+                @JoinTable()
+                others: Relation<Other[]>;
             }`,
                         },
                     ],

--- a/src/rules/enforce-relation-types.test.ts
+++ b/src/rules/enforce-relation-types.test.ts
@@ -325,6 +325,30 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
             ],
         },
         {
+            name: 'should fail on mismatched one-to-one wrapped relations',
+            options: [{ specifyRelation: 'always' }],
+            code: `class Entity {
+                @OneToOne(() => Other)
+                @JoinColumn()
+                other: Other | null;
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_specify_relation_always',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                @OneToOne(() => Other)
+                @JoinColumn()
+                other: Relation<Other | null>;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
             name: 'should fail on primitive one-to-one relations',
             code: `class Entity {
                 @OneToOne(() => Other)
@@ -478,6 +502,28 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
             ],
         },
         {
+            name: 'should fail on mismatched wrapped one-to-many relations',
+            options: [{ specifyRelation: 'always' }],
+            code: `class Entity {
+                    @OneToMany(() => Other, (other) => other.entity)
+                    others: Other[];
+                }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_specify_relation_always',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                    @OneToMany(() => Other, (other) => other.entity)
+                    others: Relation<Other[]>;
+                }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
             name: 'should fail on primitive one-to-many relations',
             code: `class Entity {
                 @OneToMany(() => Other, (other) => other.entity)
@@ -611,6 +657,28 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
             ],
         },
         {
+            name: 'should fail on mismatched wrapped many-to-one relations',
+            options: [{ specifyRelation: 'always' }],
+            code: `class Entity {
+                @ManyToOne(() => Other)
+                other: Other | null;
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_specify_relation_always',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                @ManyToOne(() => Other)
+                other: Relation<Other | null>;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
             name: 'should fail on primitive many-to-one relations',
             code: `class Entity {
                 @ManyToOne(() => Other)
@@ -731,6 +799,30 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
             errors: [
                 {
                     messageId: 'typescript_typeorm_relation_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                @ManyToMany(() => Other)
+                @JoinTable()
+                others: Relation<Other[]>;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on specify relation always many-to-many relations',
+            options: [{ specifyRelation: 'always' }],
+            code: `class Entity {
+                @ManyToMany(() => Other)
+                @JoinTable()
+                others: Other[];
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_specify_relation_always',
                     suggestions: [
                         {
                             messageId: 'typescript_typeorm_relation_suggestion',


### PR DESCRIPTION
**Motivation**: this library should support TypeORM [ESM wrappers](https://typeorm.io/#relations-in-esm-projects) and add an option to force specifying the wrapper for example in ESM codebases.

**Fixes**: #16, #17

- Add relation to examples
- Add option to force Relation wrapper
- Add support for Relation wrapper
