### PR TITLE
Handle bigint and decimal types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ## [Unreleased]
 
+### Changed
+
+- **Breaking**: `bigint` and `decimal` are now parsed correctly according to the driver ([#5](https://github.com/daniel7grant/eslint-plugin-typeorm-typescript/issues/5#issuecomment-2452988205))
+    - There is new option `driver` for `enforce-column-types`: can be 'postgres', 'mysql' or 'sqlite'
+    - If the driver is empty (default) or set to MySQL and PostgreSQL, bigint and decimal are parsed to be strings
+    - If the driver is set to SQLite, bigint and decimal are parsed to be numbers
+    - For more information, see [#5](https://github.com/daniel7grant/eslint-plugin-typeorm-typescript/issues/5#issuecomment-2455779084)
+
 ## [0.4.1] - 2024-11-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -76,9 +76,10 @@ but columns aren't), it makes it easy to make mistakes. These ESLint rules will 
 
 ### typeorm-typescript/enforce-column-types
 
-TypeORM data types and TypeScript types should be consistent. It includes the primitive types (e.g. `VARCHAR` -> `string`)
-and the nullability. By default columns are non-nullable, but if the `nullable: true` option is set, it should be unioned
-with `null` in the TypeScript types too.
+TypeORM data types and TypeScript types should be consistent. It checks the primitive types (e.g. `VARCHAR` -> `string`)
+and driver-specific types. By most drivers, `bigint` and `decimal` are parsed as string, except in SQLite (set the `driver`
+option, if you use SQLite). This rule checks the nullability too: by default columns are non-nullable, but if the `nullable: true`
+option is set, it should be unioned with `null` in the TypeScript types as well.
 
 It also handle primary columns (`number` by default), create and update columns (`date` by default) and delete columns
 (`date` and nullable by default).
@@ -88,7 +89,9 @@ It also handle primary columns (`number` by default), create and update columns 
 ```json
 {
   "rules": {
-    "typeorm-typescript/enforce-column-types": "error"
+    "typeorm-typescript/enforce-column-types": "error",
+    // If you are using SQLite, set the driver
+    "typeorm-typescript/enforce-relation-types": ["error", { "driver": "sqlite" }],
   }
 }
 ```

--- a/src/rules/enforce-column-types.test.ts
+++ b/src/rules/enforce-column-types.test.ts
@@ -50,6 +50,36 @@ ruleTester.run('enforce-column-types', enforceColumnTypes, {
             }`,
         },
         {
+            name: 'should allow matching decimal column types',
+            code: `class Entity {
+                @Column({ type: 'decimal' })
+                decimal: string;
+            }`,
+        },
+        {
+            name: 'should allow matching bigint column types',
+            code: `class Entity {
+                @Column({ type: 'bigint' })
+                big: string;
+            }`,
+        },
+        {
+            name: 'should allow matching decimal column types in SQLite',
+            code: `class Entity {
+                @Column({ type: 'decimal' })
+                decimal: number;
+            }`,
+            options: [{ driver: 'sqlite' }],
+        },
+        {
+            name: 'should allow matching bigint column types in SQLite',
+            code: `class Entity {
+                @Column({ type: 'bigint' })
+                big: number;
+            }`,
+            options: [{ driver: 'sqlite' }],
+        },
+        {
             name: 'should allow matching bool column types',
             code: `class Entity {
                 @Column({ type: 'boolean' })
@@ -360,6 +390,92 @@ ruleTester.run('enforce-column-types', enforceColumnTypes, {
                             output: `class Entity {
                 @Column({ type: 'string' })
                 str: string;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on non-string TypeScript type with decimal type',
+            code: `class Entity {
+                @Column({ type: 'decimal' })
+                num: number;
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_column_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_column_suggestion',
+                            output: `class Entity {
+                @Column({ type: 'decimal' })
+                num: string;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on non-string TypeScript type with bigint type',
+            code: `class Entity {
+                @Column({ type: 'bigint' })
+                num: number;
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_column_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_column_suggestion',
+                            output: `class Entity {
+                @Column({ type: 'bigint' })
+                num: string;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on non-number TypeScript type with decimal type in SQLite',
+            code: `class Entity {
+                @Column({ type: 'decimal' })
+                num: string;
+            }`,
+            options: [{ driver: 'sqlite' }],
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_column_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_column_suggestion',
+                            output: `class Entity {
+                @Column({ type: 'decimal' })
+                num: number;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on non-number TypeScript type with bigint type in SQLite',
+            code: `class Entity {
+                @Column({ type: 'bigint' })
+                num: string;
+            }`,
+            options: [{ driver: 'sqlite' }],
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_column_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_column_suggestion',
+                            output: `class Entity {
+                @Column({ type: 'bigint' })
+                num: number;
             }`,
                         },
                     ],

--- a/src/rules/enforce-relation-types.ts
+++ b/src/rules/enforce-relation-types.ts
@@ -19,7 +19,7 @@ const createRule = ESLintUtils.RuleCreator(
         `https://github.com/daniel7grant/eslint-plugin-typeorm-typescript#typeorm-typescript${name}`,
 );
 
-type EnforceColumnMessages =
+type EnforceRelationMessages =
     | 'typescript_typeorm_relation_missing'
     | 'typescript_typeorm_relation_mismatch'
     | 'typescript_typeorm_relation_array_to_many'
@@ -27,13 +27,13 @@ type EnforceColumnMessages =
     | 'typescript_typeorm_relation_nullable_by_default'
     | 'typescript_typeorm_relation_nullable_by_default_suggestion'
     | 'typescript_typeorm_relation_specify_relation_always';
-type Options = [
+type EnforceRelationOptions = [
     {
         specifyRelation?: 'always';
     },
 ];
 
-const enforceColumnTypes = createRule<Options, EnforceColumnMessages>({
+const enforceRelationTypes = createRule<EnforceRelationOptions, EnforceRelationMessages>({
     name: 'enforce-relation-types',
     defaultOptions: [{}],
     meta: {
@@ -111,8 +111,8 @@ const enforceColumnTypes = createRule<Options, EnforceColumnMessages>({
                 const typescriptType = convertTypeToRelationType(typeAnnotation);
 
                 if (!isTypesEqual(typeormType, typescriptType)) {
-                    let messageId: EnforceColumnMessages = 'typescript_typeorm_relation_mismatch';
-                    const suggestions: ReportSuggestionArray<EnforceColumnMessages> = [];
+                    let messageId: EnforceRelationMessages = 'typescript_typeorm_relation_mismatch';
+                    const suggestions: ReportSuggestionArray<EnforceRelationMessages> = [];
                     const fixReplace = typeToString(typeormType, typescriptType);
 
                     // Construct strings for error message
@@ -181,7 +181,7 @@ const enforceColumnTypes = createRule<Options, EnforceColumnMessages>({
                     });
                     const expectedValue = fixReplace ? ` (expected type: ${fixReplace})` : '';
 
-                    const suggestions: ReportSuggestionArray<EnforceColumnMessages> = [];
+                    const suggestions: ReportSuggestionArray<EnforceRelationMessages> = [];
                     if (fixReplace) {
                         suggestions.push({
                             messageId: 'typescript_typeorm_relation_suggestion',
@@ -210,4 +210,4 @@ const enforceColumnTypes = createRule<Options, EnforceColumnMessages>({
     },
 });
 
-export default enforceColumnTypes;
+export default enforceRelationTypes;


### PR DESCRIPTION
**Motivation**: By PostgreSQL and MySQL drivers, `bigint` and `decimal` are parsed to string while SQLite parses it to be a number. Change the default behaviour to the match the most used drivers and add support for changing the driver to SQLite.

- Handle bigint and decimal types
