### PR TITLE
Add support for undefined linting

### DIFF
--- a/src/rules/enforce-relation-types.test.ts
+++ b/src/rules/enforce-relation-types.test.ts
@@ -186,6 +186,49 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
                 others: Relation<Other[]>;
             }`,
         },
+        {
+            name: 'should allow undefined via optional marker one-to-many relations ',
+            options: [{ specifyUndefined: 'always' }],
+            code: `class Entity {
+                @OneToMany(() => Other, (other) => other.entity)
+                others?: Other[];
+            }`,
+        },
+        {
+            name: 'should allow undefined via union with undefined one-to-many relations ',
+            options: [{ specifyUndefined: 'always' }],
+            code: `class Entity {
+                @OneToMany(() => Other, (other) => other.entity)
+                others: Other[] | undefined;
+            }`,
+        },
+        {
+            name: 'should allow undefined via optional marker one-to-one relations',
+            options: [{ specifyUndefined: 'always' }],
+            code: `class Entity {
+                @OneToOne(() => Other, (other) => other.entity)
+                @JoinColumn()
+                other?: Other | null;
+            }`,
+        },
+        {
+            name: 'should allow undefined via union with undefined one-to-one relations',
+            options: [{ specifyUndefined: 'always' }],
+            code: `class Entity {
+                @OneToOne(() => Other, (other) => other.entity)
+                @JoinColumn()
+                other: Other | undefined | null;
+            }`,
+        },
+        {
+            name: 'should allow omission of undefined for lazy relations',
+            options: [{ specifyUndefined: 'always' }],
+            code: `class Entity {
+                @OneToOne(() => Other, (other) => other.entity, { nullable: false })
+                @JoinColumn()
+                other: Promise<Other>;
+            }`,
+        },
     ],
     invalid: [
         {
@@ -853,6 +896,74 @@ ruleTester.run('enforce-relation-types', enforceRelationTypes, {
                 @ManyToMany(() => Other)
                 @JoinTable()
                 others: Other[];
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on undefined one-to-many relations ',
+            options: [{ specifyUndefined: 'always' }],
+            code: `class Entity {
+                @OneToMany(() => Other, (other) => other.entity)
+                others: Other[];
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_specify_undefined_always',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                @OneToMany(() => Other, (other) => other.entity)
+                others: Other[] | undefined;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on undefined many-to-one relations ',
+            options: [{ specifyUndefined: 'always' }],
+            code: `class Entity {
+                @ManyToOne(() => Other, { nullable: false })
+                other: Other;
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_specify_undefined_always',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                @ManyToOne(() => Other, { nullable: false })
+                other: Other | undefined;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should fail on undefined one-to-one relations ',
+            options: [{ specifyUndefined: 'always' }],
+            code: `class Entity {
+                @OneToOne(() => Other, (other) => other.entity)
+                @JoinColumn()
+                other: Other | null;
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_relation_specify_undefined_always',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            output: `class Entity {
+                @OneToOne(() => Other, (other) => other.entity)
+                @JoinColumn()
+                other: Other | null | undefined;
             }`,
                         },
                     ],

--- a/src/rules/enforce-relation-types.ts
+++ b/src/rules/enforce-relation-types.ts
@@ -26,10 +26,12 @@ type EnforceRelationMessages =
     | 'typescript_typeorm_relation_suggestion'
     | 'typescript_typeorm_relation_nullable_by_default'
     | 'typescript_typeorm_relation_nullable_by_default_suggestion'
-    | 'typescript_typeorm_relation_specify_relation_always';
+    | 'typescript_typeorm_relation_specify_relation_always'
+    | 'typescript_typeorm_relation_specify_undefined_always';
 type EnforceRelationOptions = [
     {
         specifyRelation?: 'always';
+        specifyUndefined?: 'always';
     },
 ];
 
@@ -57,12 +59,18 @@ const enforceRelationTypes = createRule<EnforceRelationOptions, EnforceRelationM
                 'Make the {{ relation }} relation nullable: false.',
             typescript_typeorm_relation_specify_relation_always:
                 'To avoid circular dependencies, wrap your type of {{ propertyName }} with `Relation`{{ expectedValue }}.',
+            typescript_typeorm_relation_specify_undefined_always:
+                'TypeORM relations are undefined by default. Type of {{ propertyName }} should be undefined{{ expectedValue }}.',
         },
         schema: [
             {
                 type: 'object',
                 properties: {
                     specifyRelation: {
+                        type: 'string',
+                        enum: ['always'],
+                    },
+                    specifyUndefined: {
                         type: 'string',
                         enum: ['always'],
                     },
@@ -109,6 +117,8 @@ const enforceRelationTypes = createRule<EnforceRelationOptions, EnforceRelationM
                 }
                 const { typeAnnotation } = node.typeAnnotation;
                 const typescriptType = convertTypeToRelationType(typeAnnotation);
+                typescriptType.isOptionalUndefined =
+                    typescriptType.isOptionalUndefined || node.optional;
 
                 if (!isTypesEqual(typeormType, typescriptType)) {
                     let messageId: EnforceRelationMessages = 'typescript_typeorm_relation_mismatch';
@@ -197,6 +207,46 @@ const enforceRelationTypes = createRule<EnforceRelationOptions, EnforceRelationM
                     context.report({
                         node,
                         messageId: 'typescript_typeorm_relation_specify_relation_always',
+                        data: {
+                            propertyName,
+                            expectedValue,
+                        },
+                        suggest: suggestions,
+                        loc: node.loc,
+                    });
+                }
+
+                // If specify undefined is set to always, make sure that the typescript type can be undefined unless it is a lazy relation
+                if (
+                    context.options[0]?.specifyUndefined === 'always' &&
+                    !typescriptType.isOptionalUndefined &&
+                    !typescriptType.isLazy
+                ) {
+                    const propertyName =
+                        node.key?.type === AST_NODE_TYPES.Identifier ? node.key.name : 'property';
+                    // Make expected value unioned with undefined or optional
+                    const fixReplace = typeToString(typeormType, {
+                        ...typescriptType,
+                        isOptionalUndefined: true,
+                    });
+                    const expectedValue = fixReplace ? ` (expected type: ${fixReplace})` : '';
+
+                    const suggestions: ReportSuggestionArray<EnforceRelationMessages> = [];
+                    if (fixReplace) {
+                        suggestions.push({
+                            messageId: 'typescript_typeorm_relation_suggestion',
+                            fix: (fixer) => fixer.replaceText(typeAnnotation, fixReplace),
+                            data: {
+                                propertyName,
+                                expectedValue: fixReplace,
+                            },
+                        });
+                    }
+
+                    // Report the error
+                    context.report({
+                        node,
+                        messageId: 'typescript_typeorm_relation_specify_undefined_always',
                         data: {
                             propertyName,
                             expectedValue,


### PR DESCRIPTION
hello @daniel7grant first off wanted to thank you for creating this great eslint plugin. My team and I are currently experiencing tons of tech debt from having mistyped many of our entity fields in TypeORM and frequently face the consequences of accessing null or undefined values which aren't properly represented as such in the entity files.

We are refactoring many of these instances now thanks to this plugin, which brings me to a feature request which I've tried to implement myself in this PR.

For our relation types we would like to make it clear that by default, all relation types come back as undefined in TypeORM (if not expressed as lazy) and will have to be checked before accessed or explicitly declared in the `relations` field when querying for the entity.

I've added an option for the plugin `specifyUndefined: always` to opt into this behavior. 

Let me know if this all makes sense and what questions/comments you have