### PR TITLE
Add enforce-column-name rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ export default tseslint.config(
   {
     plugins: {'typeorm-typescript': typeormTypescriptPlugin},
     rules: {
+      "typeorm-typescript/enforce-column-name": ["error", { "prefer": "snake_case", "specifyName": "non-default" }],
       "typeorm-typescript/enforce-column-types": "error",
       "typeorm-typescript/enforce-relation-types": "warn",
       "typeorm-typescript/enforce-consistent-nullability": ["error", { "specifyNullable": "always" }]
@@ -73,6 +74,67 @@ For more information, see an example of the [legacy configuration](./examples/le
 TypeORM has no way to statically analyze if there is an inconsistency in the annotated TypeScript types.
 With the addition, that there are some confusing rules around nullability (relations are nullable by default,
 but columns aren't), it makes it easy to make mistakes. These ESLint rules will spot these issues, and suggest fixes.
+
+### typeorm-typescript/enforce-column-name
+
+TypeORM column decorators can derive a database column name from the property name, but teams often want to enforce a specific naming style or require explicit `name` declarations in non-default cases. This rule checks TypeORM column decorators whose names end with `Column` and support the `name` option.
+
+Use `prefer` to choose the database naming style:
+
+- `snake_case` (default)
+- `lowerCamelCase`
+
+Use `specifyName` to control when `name` must be written explicitly:
+
+- `non-default` (default): only require `name` when the default derived name would not match the preferred convention; redundant default names are reported
+- `always`: always require `name`
+
+#### Configuration
+
+```json
+{
+  "rules": {
+    "typeorm-typescript/enforce-column-name": ["error", {
+      "prefer": "snake_case",
+      "specifyName": "non-default"
+    }]
+  }
+}
+```
+
+#### Examples
+
+Examples of **incorrect code** for this rule:
+
+```ts
+class Entity {
+    // Name does not match snake_case convention
+    @Column({ name: "createdAt" })
+    createdAt: Date;
+
+    // Missing explicit name for non-snake_case property
+    @Column()
+    userID: string;
+}
+```
+
+Examples of **correct code** for this rule:
+
+```ts
+class Entity {
+    // Property already matches convention, no name needed
+    @Column()
+    id: number;
+
+    // Explicit name converts to snake_case
+    @Column({ name: "user_id" })
+    userID: string;
+
+    // Explicit name converts to snake_case
+    @Column({ name: "created_at" })
+    createdAt: Date;
+}
+```
 
 ### typeorm-typescript/enforce-column-types
 

--- a/README.md
+++ b/README.md
@@ -41,10 +41,10 @@ export default tseslint.config(
   {
     plugins: {'typeorm-typescript': typeormTypescriptPlugin},
     rules: {
-      "typeorm-typescript/enforce-column-name": ["error", { "prefer": "snake_case", "specifyName": "non-default" }],
       "typeorm-typescript/enforce-column-types": "error",
       "typeorm-typescript/enforce-relation-types": "warn",
-      "typeorm-typescript/enforce-consistent-nullability": ["error", { "specifyNullable": "always" }]
+      "typeorm-typescript/enforce-consistent-nullability": ["error", { "specifyNullable": "always" }],
+      "typeorm-typescript/enforce-column-name": ["error", { "prefer": "snake_case", "specifyName": "non-default" }]
     }
   }
 );
@@ -74,67 +74,6 @@ For more information, see an example of the [legacy configuration](./examples/le
 TypeORM has no way to statically analyze if there is an inconsistency in the annotated TypeScript types.
 With the addition, that there are some confusing rules around nullability (relations are nullable by default,
 but columns aren't), it makes it easy to make mistakes. These ESLint rules will spot these issues, and suggest fixes.
-
-### typeorm-typescript/enforce-column-name
-
-TypeORM column decorators can derive a database column name from the property name, but teams often want to enforce a specific naming style or require explicit `name` declarations in non-default cases. This rule checks TypeORM column decorators whose names end with `Column` and support the `name` option.
-
-Use `prefer` to choose the database naming style:
-
-- `snake_case` (default)
-- `lowerCamelCase`
-
-Use `specifyName` to control when `name` must be written explicitly:
-
-- `non-default` (default): only require `name` when the default derived name would not match the preferred convention; redundant default names are reported
-- `always`: always require `name`
-
-#### Configuration
-
-```json
-{
-  "rules": {
-    "typeorm-typescript/enforce-column-name": ["error", {
-      "prefer": "snake_case",
-      "specifyName": "non-default"
-    }]
-  }
-}
-```
-
-#### Examples
-
-Examples of **incorrect code** for this rule:
-
-```ts
-class Entity {
-    // Name does not match snake_case convention
-    @Column({ name: "createdAt" })
-    createdAt: Date;
-
-    // Missing explicit name for non-snake_case property
-    @Column()
-    userID: string;
-}
-```
-
-Examples of **correct code** for this rule:
-
-```ts
-class Entity {
-    // Property already matches convention, no name needed
-    @Column()
-    id: number;
-
-    // Explicit name converts to snake_case
-    @Column({ name: "user_id" })
-    userID: string;
-
-    // Explicit name converts to snake_case
-    @Column({ name: "created_at" })
-    createdAt: Date;
-}
-```
 
 ### typeorm-typescript/enforce-column-types
 
@@ -368,5 +307,66 @@ class Entity {
     @OneToOne(() => Other, { nullable: true })
     @JoinColumn()
     other: Other | null;
+}
+```
+
+### typeorm-typescript/enforce-column-name
+
+TypeORM column decorators can derive a database column name from the property name, but teams often want to enforce a specific naming style or require explicit `name` declarations in non-default cases. This rule checks TypeORM column decorators whose names end with `Column` and support the `name` option.
+
+Use `prefer` to choose the database naming style:
+
+- `snake_case` (default)
+- `lowerCamelCase`
+
+Use `specifyName` to control when `name` must be written explicitly:
+
+- `non-default` (default): only require `name` when the default derived name would not match the preferred convention; redundant default names are reported
+- `always`: always require `name`
+
+#### Configuration
+
+```json
+{
+  "rules": {
+    "typeorm-typescript/enforce-column-name": ["error", {
+      "prefer": "snake_case",
+      "specifyName": "non-default"
+    }]
+  }
+}
+```
+
+#### Examples
+
+Examples of **incorrect code** for this rule:
+
+```ts
+class Entity {
+    // Name does not match snake_case convention
+    @Column({ name: "createdAt" })
+    createdAt: Date;
+
+    // Missing explicit name for non-snake_case property
+    @Column()
+    userID: string;
+}
+```
+
+Examples of **correct code** for this rule:
+
+```ts
+class Entity {
+    // Property already matches convention, no name needed
+    @Column()
+    id: number;
+
+    // Explicit name converts to snake_case
+    @Column({ name: "user_id" })
+    userID: string;
+
+    // Explicit name converts to snake_case
+    @Column({ name: "created_at" })
+    createdAt: Date;
 }
 ```

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,11 @@
 import { FlatConfig } from '@typescript-eslint/utils/ts-eslint';
+import enforceColumnName from './rules/enforce-column-name.js';
 import enforceColumnTypes from './rules/enforce-column-types.js';
 import enforceConsistentNullability from './rules/enforce-consistent-nullability.js';
 import enforceRelationTypes from './rules/enforce-relation-types.js';
 
 export const rules = {
+    'enforce-column-name': enforceColumnName,
     'enforce-column-types': enforceColumnTypes,
     'enforce-consistent-nullability': enforceConsistentNullability,
     'enforce-relation-types': enforceRelationTypes,

--- a/src/rules/enforce-column-name.test.ts
+++ b/src/rules/enforce-column-name.test.ts
@@ -1,0 +1,205 @@
+import path from 'path';
+import * as vitest from 'vitest';
+import tsParser from '@typescript-eslint/parser';
+import { RuleTester } from '@typescript-eslint/rule-tester';
+import enforceColumnName from './enforce-column-name.js';
+
+RuleTester.afterAll = vitest.afterAll;
+RuleTester.it = vitest.it;
+RuleTester.itOnly = vitest.it.only;
+RuleTester.describe = vitest.describe;
+
+const ruleTester = new RuleTester({
+    languageOptions: {
+        parser: tsParser,
+        parserOptions: {
+            project: './tsconfig.json',
+            tsconfigRootDir: path.join(__dirname, '../../tests'),
+        },
+    },
+});
+
+ruleTester.run('enforce-column-name', enforceColumnName, {
+    valid: [
+        {
+            name: 'should allow implicit name when property already matches convention',
+            code: `class Entity {
+                @Column()
+                id: number;
+            }`,
+        },
+        {
+            name: 'should allow explicit snake_case names with always',
+            code: `class Entity {
+                @Column({ name: 'created_at' })
+                createdAt: Date;
+            }`,
+            options: [{ specifyName: 'always' }],
+        },
+        {
+            name: 'should allow implicit lower camel case when preferred',
+            code: `class Entity {
+                @Column()
+                createdAt: Date;
+            }`,
+            options: [{ prefer: 'lowerCamelCase' }],
+        },
+        {
+            name: 'should allow acronym conversion for userID in snake case',
+            code: `class Entity {
+                @Column({ name: 'user_id' })
+                userID: string;
+            }`,
+            options: [{ specifyName: 'always' }],
+        },
+        {
+            name: 'should allow create date column with explicit name',
+            code: `class Entity {
+                @CreateDateColumn({ name: 'created_at' })
+                createdAt: Date;
+            }`,
+            options: [{ specifyName: 'always' }],
+        },
+        {
+            name: 'should ignore dynamic name values',
+            code: `const columnName = 'created_at';
+            class Entity {
+                @Column({ name: columnName })
+                createdAt: Date;
+            }`,
+        },
+    ],
+    invalid: [
+        {
+            name: 'should require name when always is set',
+            code: `class Entity {
+                @Column()
+                createdAt: Date;
+            }`,
+            options: [{ specifyName: 'always' }],
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_column_name_missing',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_column_name_suggestion_add',
+                            output: `class Entity {
+                @Column({ name: 'created_at' })
+                createdAt: Date;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should reject non-snake-case explicit name by default',
+            code: `class Entity {
+                @Column({ name: 'createdAt' })
+                createdAt: Date;
+            }`,
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_column_name_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_column_name_suggestion_replace',
+                            output: `class Entity {
+                @Column({ name: 'created_at' })
+                createdAt: Date;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should reject redundant default name in non-default mode',
+            code: `class Entity {
+                @Column({ name: 'createdAt' })
+                createdAt: Date;
+            }`,
+            options: [{ prefer: 'lowerCamelCase', specifyName: 'non-default' }],
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_column_name_superfluous',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_column_name_suggestion_remove',
+                            output: `class Entity {
+                @Column()
+                createdAt: Date;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should require explicit lower camel case override when property is not lower camel case',
+            code: `class Entity {
+                @Column()
+                userID: string;
+            }`,
+            options: [{ prefer: 'lowerCamelCase', specifyName: 'non-default' }],
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_column_name_missing',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_column_name_suggestion_add',
+                            output: `class Entity {
+                @Column({ name: 'userId' })
+                userID: string;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should reject wrong lower camel case explicit name',
+            code: `class Entity {
+                @Column({ name: 'user_id' })
+                userID: string;
+            }`,
+            options: [{ prefer: 'lowerCamelCase', specifyName: 'always' }],
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_column_name_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_column_name_suggestion_replace',
+                            output: `class Entity {
+                @Column({ name: 'userId' })
+                userID: string;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+        {
+            name: 'should handle acronym conversion for snake case mismatches',
+            code: `class Entity {
+                @PrimaryColumn({ name: 'user_i_d' })
+                userID: string;
+            }`,
+            options: [{ specifyName: 'always' }],
+            errors: [
+                {
+                    messageId: 'typescript_typeorm_column_name_mismatch',
+                    suggestions: [
+                        {
+                            messageId: 'typescript_typeorm_column_name_suggestion_replace',
+                            output: `class Entity {
+                @PrimaryColumn({ name: 'user_id' })
+                userID: string;
+            }`,
+                        },
+                    ],
+                },
+            ],
+        },
+    ],
+});

--- a/src/rules/enforce-column-name.ts
+++ b/src/rules/enforce-column-name.ts
@@ -1,0 +1,319 @@
+import { AST_NODE_TYPES, ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import {
+    findEitherDecoratorArguments,
+    findObjectArgument,
+    findParentClass,
+} from '../utils/treeTraversal.js';
+
+type Prefer = 'snake_case' | 'lowerCamelCase';
+type SpecifyName = 'always' | 'non-default';
+
+type ErrorMessages =
+    | 'typescript_typeorm_column_name_missing'
+    | 'typescript_typeorm_column_name_mismatch'
+    | 'typescript_typeorm_column_name_superfluous'
+    | 'typescript_typeorm_column_name_suggestion_add'
+    | 'typescript_typeorm_column_name_suggestion_replace'
+    | 'typescript_typeorm_column_name_suggestion_remove';
+
+type Options = [
+    {
+        prefer?: Prefer;
+        specifyName?: SpecifyName;
+    },
+];
+
+const COLUMN_DECORATORS = [
+    'Column',
+    'CreateDateColumn',
+    'DeleteDateColumn',
+    'ObjectIdColumn',
+    'PrimaryColumn',
+    'PrimaryGeneratedColumn',
+    'UpdateDateColumn',
+    'VersionColumn',
+    'ViewColumn',
+    'VirtualColumn',
+] as const;
+
+function splitWords(value: string): string[] {
+    return value
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+        .trim()
+        .split(/[^A-Za-z0-9]+/)
+        .filter(Boolean);
+}
+
+function toSnakeCase(value: string): string {
+    return splitWords(value)
+        .map((word) => word.toLowerCase())
+        .join('_');
+}
+
+function toLowerCamelCase(value: string): string {
+    const words = splitWords(value).map((word) => word.toLowerCase());
+    return words
+        .map((word, index) => (index === 0 ? word : `${word[0].toUpperCase()}${word.slice(1)}`))
+        .join('');
+}
+
+function getExpectedName(propertyName: string, prefer: Prefer): string {
+    return prefer === 'snake_case' ? toSnakeCase(propertyName) : toLowerCamelCase(propertyName);
+}
+
+function getStaticNameProperty(
+    objectArgument: TSESTree.CallExpressionArgument | undefined,
+): TSESTree.Property | undefined {
+    if (!objectArgument || objectArgument.type !== AST_NODE_TYPES.ObjectExpression) {
+        return undefined;
+    }
+
+    return objectArgument.properties.find(
+        (property): property is TSESTree.Property =>
+            property.type === AST_NODE_TYPES.Property &&
+            property.key.type === AST_NODE_TYPES.Identifier &&
+            property.key.name === 'name',
+    );
+}
+
+function getStringLiteralValue(property: TSESTree.Property | undefined): string | undefined {
+    if (
+        !property ||
+        property.value.type !== AST_NODE_TYPES.Literal ||
+        typeof property.value.value !== 'string'
+    ) {
+        return undefined;
+    }
+    return property.value.value;
+}
+
+const createRule = ESLintUtils.RuleCreator(
+    (name) =>
+        `https://github.com/daniel7grant/eslint-plugin-typeorm-typescript#typeorm-typescript${name}`,
+);
+
+const enforceColumnName = createRule<Options, ErrorMessages>({
+    name: 'enforce-column-name',
+    defaultOptions: [{ prefer: 'snake_case', specifyName: 'non-default' }],
+    meta: {
+        type: 'problem',
+        docs: {
+            description: 'TypeORM column names should follow a consistent naming convention.',
+        },
+        hasSuggestions: true,
+        messages: {
+            typescript_typeorm_column_name_missing:
+                'Column name of {{ propertyName }}{{ className }} must be specified explicitly{{ expectedValue }}.',
+            typescript_typeorm_column_name_mismatch:
+                'Column name of {{ propertyName }}{{ className }} does not match the expected convention{{ expectedValue }}.',
+            typescript_typeorm_column_name_superfluous:
+                'Column name of {{ propertyName }}{{ className }} matches the default convention and can be removed.',
+            typescript_typeorm_column_name_suggestion_add:
+                'Add name: {{ expectedValue }} to {{ propertyName }}.',
+            typescript_typeorm_column_name_suggestion_replace:
+                'Change the name of {{ propertyName }} to {{ expectedValue }}.',
+            typescript_typeorm_column_name_suggestion_remove:
+                'Remove redundant name from {{ propertyName }}.',
+        },
+        schema: [
+            {
+                type: 'object',
+                properties: {
+                    prefer: {
+                        type: 'string',
+                        enum: ['snake_case', 'lowerCamelCase'],
+                    },
+                    specifyName: {
+                        type: 'string',
+                        enum: ['always', 'non-default'],
+                    },
+                },
+                additionalProperties: false,
+            },
+        ],
+    },
+    create(context, [{ prefer = 'snake_case', specifyName = 'non-default' }]) {
+        return {
+            PropertyDefinition(node) {
+                const columnArguments = findEitherDecoratorArguments(node.decorators, [
+                    ...COLUMN_DECORATORS,
+                ]);
+                if (!columnArguments || node.key.type !== AST_NODE_TYPES.Identifier) {
+                    return;
+                }
+
+                const [, decoratorArguments] = columnArguments;
+                const propertyName = node.key.name;
+                const expectedName = getExpectedName(propertyName, prefer);
+                const optionsArgument = findObjectArgument(decoratorArguments);
+                const nameProperty = getStaticNameProperty(optionsArgument);
+                const explicitName = getStringLiteralValue(nameProperty);
+                const classObject = findParentClass(node);
+                const className = classObject?.id ? ` in ${classObject.id.name}` : '';
+                const expectedValue = ` (expected name: ${expectedName})`;
+
+                if (!nameProperty) {
+                    if (specifyName === 'always' || propertyName !== expectedName) {
+                        const reportedNode =
+                            optionsArgument ?? decoratorArguments[0]?.parent ?? node;
+                        context.report({
+                            node: reportedNode,
+                            messageId: 'typescript_typeorm_column_name_missing',
+                            data: {
+                                className,
+                                propertyName,
+                                expectedValue,
+                            },
+                            suggest: [
+                                {
+                                    messageId: 'typescript_typeorm_column_name_suggestion_add',
+                                    data: {
+                                        propertyName,
+                                        expectedValue: `'${expectedName}'`,
+                                    },
+                                    fix: (fixer) => {
+                                        if (!decoratorArguments.length) {
+                                            const decorator = node.decorators?.find(
+                                                (item) =>
+                                                    item.expression.type ===
+                                                        AST_NODE_TYPES.CallExpression &&
+                                                    item.expression.callee.type ===
+                                                        AST_NODE_TYPES.Identifier &&
+                                                    COLUMN_DECORATORS.includes(
+                                                        item.expression.callee
+                                                            .name as (typeof COLUMN_DECORATORS)[number],
+                                                    ),
+                                            );
+                                            if (!decorator) {
+                                                return null;
+                                            }
+                                            return fixer.insertTextAfterRange(
+                                                [decorator.range[0], decorator.range[1] - 1],
+                                                `{ name: '${expectedName}' }`,
+                                            );
+                                        }
+
+                                        if (
+                                            optionsArgument?.type ===
+                                            AST_NODE_TYPES.ObjectExpression
+                                        ) {
+                                            if (optionsArgument.properties.length === 0) {
+                                                return fixer.insertTextAfterRange(
+                                                    [
+                                                        optionsArgument.range[0],
+                                                        optionsArgument.range[1] - 1,
+                                                    ],
+                                                    ` name: '${expectedName}' `,
+                                                );
+                                            }
+                                            return fixer.insertTextAfter(
+                                                optionsArgument.properties[
+                                                    optionsArgument.properties.length - 1
+                                                ],
+                                                `, name: '${expectedName}'`,
+                                            );
+                                        }
+
+                                        return fixer.insertTextAfter(
+                                            decoratorArguments[decoratorArguments.length - 1],
+                                            `, { name: '${expectedName}' }`,
+                                        );
+                                    },
+                                },
+                            ],
+                            loc: reportedNode.loc,
+                        });
+                    }
+                    return;
+                }
+
+                if (explicitName === undefined) {
+                    return;
+                }
+
+                if (explicitName !== expectedName) {
+                    context.report({
+                        node: nameProperty.value,
+                        messageId: 'typescript_typeorm_column_name_mismatch',
+                        data: {
+                            className,
+                            propertyName,
+                            expectedValue,
+                        },
+                        suggest: [
+                            {
+                                messageId: 'typescript_typeorm_column_name_suggestion_replace',
+                                data: {
+                                    propertyName,
+                                    expectedValue: `'${expectedName}'`,
+                                },
+                                fix: (fixer) =>
+                                    fixer.replaceText(nameProperty.value, `'${expectedName}'`),
+                            },
+                        ],
+                        loc: nameProperty.loc,
+                    });
+                    return;
+                }
+
+                if (specifyName === 'non-default' && propertyName === expectedName) {
+                    context.report({
+                        node: nameProperty,
+                        messageId: 'typescript_typeorm_column_name_superfluous',
+                        data: {
+                            className,
+                            propertyName,
+                        },
+                        suggest: [
+                            {
+                                messageId: 'typescript_typeorm_column_name_suggestion_remove',
+                                data: {
+                                    propertyName,
+                                },
+                                fix: (fixer) => {
+                                    if (
+                                        !optionsArgument ||
+                                        optionsArgument.type !== AST_NODE_TYPES.ObjectExpression
+                                    ) {
+                                        return null;
+                                    }
+
+                                    if (optionsArgument.properties.length === 1) {
+                                        const objectIndex = decoratorArguments.findIndex(
+                                            (argument) => argument === optionsArgument,
+                                        );
+                                        if (objectIndex > 0) {
+                                            return fixer.removeRange([
+                                                decoratorArguments[objectIndex - 1].range[1],
+                                                optionsArgument.range[1],
+                                            ]);
+                                        }
+                                        return fixer.remove(optionsArgument);
+                                    }
+
+                                    const propertyIndex = optionsArgument.properties.findIndex(
+                                        (property) => property === nameProperty,
+                                    );
+                                    if (propertyIndex > 0) {
+                                        return fixer.removeRange([
+                                            optionsArgument.properties[propertyIndex - 1].range[1],
+                                            nameProperty.range[1],
+                                        ]);
+                                    }
+                                    return fixer.removeRange([
+                                        nameProperty.range[0],
+                                        optionsArgument.properties[propertyIndex + 1].range[0],
+                                    ]);
+                                },
+                            },
+                        ],
+                        loc: nameProperty.loc,
+                    });
+                }
+            },
+        };
+    },
+});
+
+export default enforceColumnName;

--- a/src/rules/enforce-column-name.ts
+++ b/src/rules/enforce-column-name.ts
@@ -1,9 +1,14 @@
-import { AST_NODE_TYPES, ESLintUtils, TSESTree } from '@typescript-eslint/utils';
+import { AST_NODE_TYPES, ESLintUtils } from '@typescript-eslint/utils';
 import {
     findEitherDecoratorArguments,
     findObjectArgument,
     findParentClass,
 } from '../utils/treeTraversal.js';
+import {
+    getExpectedName,
+    getStaticNameProperty,
+    getStringLiteralValue,
+} from '../utils/columnName.js';
 
 type Prefer = 'snake_case' | 'lowerCamelCase';
 type SpecifyName = 'always' | 'non-default';
@@ -35,58 +40,6 @@ const COLUMN_DECORATORS = [
     'ViewColumn',
     'VirtualColumn',
 ] as const;
-
-function splitWords(value: string): string[] {
-    return value
-        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
-        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
-        .trim()
-        .split(/[^A-Za-z0-9]+/)
-        .filter(Boolean);
-}
-
-function toSnakeCase(value: string): string {
-    return splitWords(value)
-        .map((word) => word.toLowerCase())
-        .join('_');
-}
-
-function toLowerCamelCase(value: string): string {
-    const words = splitWords(value).map((word) => word.toLowerCase());
-    return words
-        .map((word, index) => (index === 0 ? word : `${word[0].toUpperCase()}${word.slice(1)}`))
-        .join('');
-}
-
-function getExpectedName(propertyName: string, prefer: Prefer): string {
-    return prefer === 'snake_case' ? toSnakeCase(propertyName) : toLowerCamelCase(propertyName);
-}
-
-function getStaticNameProperty(
-    objectArgument: TSESTree.CallExpressionArgument | undefined,
-): TSESTree.Property | undefined {
-    if (!objectArgument || objectArgument.type !== AST_NODE_TYPES.ObjectExpression) {
-        return undefined;
-    }
-
-    return objectArgument.properties.find(
-        (property): property is TSESTree.Property =>
-            property.type === AST_NODE_TYPES.Property &&
-            property.key.type === AST_NODE_TYPES.Identifier &&
-            property.key.name === 'name',
-    );
-}
-
-function getStringLiteralValue(property: TSESTree.Property | undefined): string | undefined {
-    if (
-        !property ||
-        property.value.type !== AST_NODE_TYPES.Literal ||
-        typeof property.value.value !== 'string'
-    ) {
-        return undefined;
-    }
-    return property.value.value;
-}
 
 const createRule = ESLintUtils.RuleCreator(
     (name) =>

--- a/src/utils/columnName.ts
+++ b/src/utils/columnName.ts
@@ -1,0 +1,55 @@
+import { AST_NODE_TYPES, TSESTree } from '@typescript-eslint/utils';
+
+export function splitWords(value: string): string[] {
+    return value
+        .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+        .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+        .trim()
+        .split(/[^A-Za-z0-9]+/)
+        .filter(Boolean);
+}
+
+export function toSnakeCase(value: string): string {
+    return splitWords(value)
+        .map((word) => word.toLowerCase())
+        .join('_');
+}
+
+export function toLowerCamelCase(value: string): string {
+    const words = splitWords(value).map((word) => word.toLowerCase());
+    return words
+        .map((word, index) => (index === 0 ? word : `${word[0].toUpperCase()}${word.slice(1)}`))
+        .join('');
+}
+
+type Prefer = 'snake_case' | 'lowerCamelCase';
+
+export function getExpectedName(propertyName: string, prefer: Prefer): string {
+    return prefer === 'snake_case' ? toSnakeCase(propertyName) : toLowerCamelCase(propertyName);
+}
+
+export function getStaticNameProperty(
+    objectArgument: TSESTree.CallExpressionArgument | undefined,
+): TSESTree.Property | undefined {
+    if (!objectArgument || objectArgument.type !== AST_NODE_TYPES.ObjectExpression) {
+        return undefined;
+    }
+
+    return objectArgument.properties.find(
+        (property): property is TSESTree.Property =>
+            property.type === AST_NODE_TYPES.Property &&
+            property.key.type === AST_NODE_TYPES.Identifier &&
+            property.key.name === 'name',
+    );
+}
+
+export function getStringLiteralValue(property: TSESTree.Property | undefined): string | undefined {
+    if (
+        !property ||
+        property.value.type !== AST_NODE_TYPES.Literal ||
+        typeof property.value.value !== 'string'
+    ) {
+        return undefined;
+    }
+    return property.value.value;
+}


### PR DESCRIPTION
Added the `enforce-column-name` rule to constrain database field names; this has not been added to the recommended rules