### PR TITLE
Update dependencies for eslint 10 compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
             "version": "0.5.3",
             "license": "ISC",
             "dependencies": {
-                "@typescript-eslint/parser": "^8.0.0",
-                "@typescript-eslint/utils": "^8.0.0",
+                "@typescript-eslint/parser": "^8.59.1",
+                "@typescript-eslint/utils": "^8.59.1",
                 "typescript": "^6.0.2",
                 "vite": "^7.0.5"
             },
@@ -18,7 +18,7 @@
                 "@eslint/js": "^10.0.1",
                 "@types/eslint": "^9.6.0",
                 "@types/node": "^25.0.3",
-                "@typescript-eslint/rule-tester": "^8.0.0",
+                "@typescript-eslint/rule-tester": "^8.59.1",
                 "eslint": "^10.1.0",
                 "eslint-config-prettier": "^10.0.1",
                 "eslint-plugin-prettier": "^5.0.1",
@@ -1030,6 +1030,30 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/@typescript-eslint/eslint-plugin/node_modules/@typescript-eslint/utils": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+            "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
         "node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
             "version": "7.0.5",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -1041,15 +1065,15 @@
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
-            "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.1.tgz",
+            "integrity": "sha512-HDQH9O/47Dxi1ceDhBXdaldtf/WV9yRYMjbjCuNk3qnaTD564qwv61Y7+gTxwxRKzSrgO5uhtw584igXVuuZkA==",
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.58.2",
-                "@typescript-eslint/types": "8.58.2",
-                "@typescript-eslint/typescript-estree": "8.58.2",
-                "@typescript-eslint/visitor-keys": "8.58.2",
+                "@typescript-eslint/scope-manager": "8.59.1",
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/typescript-estree": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1064,10 +1088,134 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/project-service": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+            "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.59.1",
+                "@typescript-eslint/types": "^8.59.1",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+            "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+            "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/types": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+            "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+            "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.59.1",
+                "@typescript-eslint/tsconfig-utils": "8.59.1",
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+            "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.59.1",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/parser/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/@typescript-eslint/project-service": {
             "version": "8.58.2",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.2.tgz",
             "integrity": "sha512-Cq6UfpZZk15+r87BkIh5rDpi38W4b+Sjnb8wQCPPDDweS/LRCFjCyViEbzHk5Ck3f2QDfgmlxqSa7S7clDtlfg==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@typescript-eslint/tsconfig-utils": "^8.58.2",
@@ -1086,15 +1234,15 @@
             }
         },
         "node_modules/@typescript-eslint/rule-tester": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.58.2.tgz",
-            "integrity": "sha512-HF7ry5ZhQSLn4JAJfQCPX39D6BE5MhYXE743I0phrJw1BvB0adH8JpsEc4owCxEESQflodyhRWNUZY+m2EVenw==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/rule-tester/-/rule-tester-8.59.1.tgz",
+            "integrity": "sha512-VAlTRylRP+zh2jepYylwEllQSI8yP0QWQqUKc3xcPbuSlnDeC0CjbpWAOp5CrqfGl9ZMGw74BjZnutb7mILOzA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/parser": "8.58.2",
-                "@typescript-eslint/typescript-estree": "8.58.2",
-                "@typescript-eslint/utils": "8.58.2",
+                "@typescript-eslint/parser": "8.59.1",
+                "@typescript-eslint/typescript-estree": "8.59.1",
+                "@typescript-eslint/utils": "8.59.1",
                 "ajv": "^6.12.6",
                 "json-stable-stringify-without-jsonify": "^1.0.1",
                 "lodash.merge": "4.6.2",
@@ -1111,10 +1259,123 @@
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0"
             }
         },
+        "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/project-service": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+            "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.59.1",
+                "@typescript-eslint/types": "^8.59.1",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+            "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/types": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+            "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+            "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.59.1",
+                "@typescript-eslint/tsconfig-utils": "8.59.1",
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/rule-tester/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+            "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.59.1",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/rule-tester/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/@typescript-eslint/scope-manager": {
             "version": "8.58.2",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.2.tgz",
             "integrity": "sha512-SgmyvDPexWETQek+qzZnrG6844IaO02UVyOLhI4wpo82dpZJY9+6YZCKAMFzXb7qhx37mFK1QcPQ18tud+vo6Q==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@typescript-eslint/types": "8.58.2",
@@ -1132,6 +1393,7 @@
             "version": "8.58.2",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.2.tgz",
             "integrity": "sha512-3SR+RukipDvkkKp/d0jP0dyzuls3DbGmwDpVEc5wqk5f38KFThakqAAO0XMirWAE+kT00oTauTbzMFGPoAzB0A==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1169,10 +1431,35 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/@typescript-eslint/type-utils/node_modules/@typescript-eslint/utils": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+            "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
         "node_modules/@typescript-eslint/types": {
             "version": "8.58.2",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.2.tgz",
             "integrity": "sha512-9TukXyATBQf/Jq9AMQXfvurk+G5R2MwfqQGDR2GzGz28HvY/lXNKGhkY+6IOubwcquikWk5cjlgPvD2uAA7htQ==",
+            "dev": true,
             "license": "MIT",
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1186,6 +1473,7 @@
             "version": "8.58.2",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.2.tgz",
             "integrity": "sha512-ELGuoofuhhoCvNbQjFFiobFcGgcDCEm0ThWdmO4Z0UzLqPXS3KFvnEZ+SHewwOYHjM09tkzOWXNTv9u6Gqtyuw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@typescript-eslint/project-service": "8.58.2",
@@ -1210,15 +1498,15 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.58.2",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
-            "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.1.tgz",
+            "integrity": "sha512-3pIeoXhCeYH9FSCBI8P3iNwJlGuzPlYKkTlen2O9T1DSeeg8UG8jstq6BLk+Mda0qup7mgk4z4XL4OzRaxZ8LA==",
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.58.2",
-                "@typescript-eslint/types": "8.58.2",
-                "@typescript-eslint/typescript-estree": "8.58.2"
+                "@typescript-eslint/scope-manager": "8.59.1",
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/typescript-estree": "8.59.1"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1232,10 +1520,134 @@
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/project-service": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.1.tgz",
+            "integrity": "sha512-+MuHQlHiEr00Of/IQbE/MmEoi44znZHbR/Pz7Opq4HryUOlRi+/44dro9Ycy8Fyo+/024IWtw8m4JUMCGTYxDg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/tsconfig-utils": "^8.59.1",
+                "@typescript-eslint/types": "^8.59.1",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/scope-manager": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.1.tgz",
+            "integrity": "sha512-LwuHQI4pDOYVKvmH2dkaJo6YZCSgouVgnS/z7yBPKBMvgtBvyLqiLy9Z6b7+m/TRcX1NFYUqZetI5Y+aT4GEfg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/tsconfig-utils": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.1.tgz",
+            "integrity": "sha512-/0nEyPbX7gRsk0Uwfe4ALwwgxuA66d/l2mhRDNlAvaj4U3juhUtJNq0DsY8M2AYwwb9rEq2hrC3IcIcEt++iJA==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/types": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.1.tgz",
+            "integrity": "sha512-ZDCjgccSdYPw5Bxh+my4Z0lJU96ZDN7jbBzvmEn0FZx3RtU1C7VWl6NbDx94bwY3V5YsgwRzJPOgeY2Q/nLG8A==",
+            "license": "MIT",
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/typescript-estree": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.1.tgz",
+            "integrity": "sha512-OUd+vJS05sSkOip+BkZ/2NS8RMxrAAJemsC6vU3kmfLyeaJT0TftHkV9mcx2107MmsBVXXexhVu4F0TZXyMl4g==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/project-service": "8.59.1",
+                "@typescript-eslint/tsconfig-utils": "8.59.1",
+                "@typescript-eslint/types": "8.59.1",
+                "@typescript-eslint/visitor-keys": "8.59.1",
+                "debug": "^4.4.3",
+                "minimatch": "^10.2.2",
+                "semver": "^7.7.3",
+                "tinyglobby": "^0.2.15",
+                "ts-api-utils": "^2.5.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/@typescript-eslint/visitor-keys": {
+            "version": "8.59.1",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.1.tgz",
+            "integrity": "sha512-LdDNl6C5iJExcM0Yh0PwAIBb9PrSiCsWamF/JyEZawm3kFDnRoaq3LGE4bpyRao/fWeGKKyw7icx0YxrLFC5Cg==",
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/types": "8.59.1",
+                "eslint-visitor-keys": "^5.0.0"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            }
+        },
+        "node_modules/@typescript-eslint/utils/node_modules/eslint-visitor-keys": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
+            "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": "^20.19.0 || ^22.13.0 || >=24"
+            },
+            "funding": {
+                "url": "https://opencollective.com/eslint"
+            }
+        },
         "node_modules/@typescript-eslint/visitor-keys": {
             "version": "8.58.2",
             "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.2.tgz",
             "integrity": "sha512-f1WO2Lx8a9t8DARmcWAUPJbu0G20bJlj8L4z72K00TMeJAoyLr/tHhI/pzYBLrR4dXWkcxO1cWYZEOX8DKHTqA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@typescript-eslint/types": "8.58.2",
@@ -1253,6 +1665,7 @@
             "version": "5.0.1",
             "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
             "integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
+            "dev": true,
             "license": "Apache-2.0",
             "engines": {
                 "node": "^20.19.0 || ^22.13.0 || >=24"
@@ -2533,6 +2946,55 @@
                 "@typescript-eslint/parser": "8.58.2",
                 "@typescript-eslint/typescript-estree": "8.58.2",
                 "@typescript-eslint/utils": "8.58.2"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/parser": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.2.tgz",
+            "integrity": "sha512-/Zb/xaIDfxeJnvishjGdcR4jmr7S+bda8PKNhRGdljDM+elXhlvN0FyPSsMnLmJUrVG9aPO6dof80wjMawsASg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2",
+                "@typescript-eslint/visitor-keys": "8.58.2",
+                "debug": "^4.4.3"
+            },
+            "engines": {
+                "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+            },
+            "funding": {
+                "type": "opencollective",
+                "url": "https://opencollective.com/typescript-eslint"
+            },
+            "peerDependencies": {
+                "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
+                "typescript": ">=4.8.4 <6.1.0"
+            }
+        },
+        "node_modules/typescript-eslint/node_modules/@typescript-eslint/utils": {
+            "version": "8.58.2",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.2.tgz",
+            "integrity": "sha512-QZfjHNEzPY8+l0+fIXMvuQ2sJlplB4zgDZvA+NmvZsZv3EQwOcc1DuIU1VJUTWZ/RKouBMhDyNaBMx4sWvrzRA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@eslint-community/eslint-utils": "^4.9.1",
+                "@typescript-eslint/scope-manager": "8.58.2",
+                "@typescript-eslint/types": "8.58.2",
+                "@typescript-eslint/typescript-estree": "8.58.2"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
         "@eslint/js": "^10.0.1",
         "@types/eslint": "^9.6.0",
         "@types/node": "^25.0.3",
-        "@typescript-eslint/rule-tester": "^8.0.0",
+        "@typescript-eslint/rule-tester": "^8.59.1",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.0.1",
         "eslint-plugin-prettier": "^5.0.1",
@@ -53,8 +53,8 @@
         "vitest": "^3.0.4"
     },
     "dependencies": {
-        "@typescript-eslint/parser": "^8.0.0",
-        "@typescript-eslint/utils": "^8.0.0",
+        "@typescript-eslint/parser": "^8.59.1",
+        "@typescript-eslint/utils": "^8.59.1",
         "typescript": "^6.0.2",
         "vite": "^7.0.5"
     }


### PR DESCRIPTION
These were the dependencies I had to bump to get eslint-plugin-typeorm-typescript working under eslint@10. Hope this is useful!